### PR TITLE
Vtu11 testing header

### DIFF
--- a/test/base64_test.cpp
+++ b/test/base64_test.cpp
@@ -7,7 +7,7 @@
 //  License: BSD License ; see LICENSE
 //
 
-#include "external/catch2/catch.hpp"
+#include "vtu11_testing.hpp"
 #include "inc/base64.hpp"
 
 #include <vector>

--- a/test/vtu11_testing.hpp
+++ b/test/vtu11_testing.hpp
@@ -1,0 +1,10 @@
+//          __        ____ ____
+// ___  ___/  |_ __ _/_   /_   |
+// \  \/ /\   __\  |  \   ||   |
+//  \   /  |  | |  |  /   ||   |
+//   \_/   |__| |____/|___||___|
+//
+//  License: BSD License ; see LICENSE
+//
+
+#include "external/catch2/catch.hpp"

--- a/test/write_Pyramids3D_test.cpp
+++ b/test/write_Pyramids3D_test.cpp
@@ -7,7 +7,7 @@
 //  License: BSD License ; see LICENSE
 //
 
-#include "external/catch2/catch.hpp"
+#include "vtu11_testing.hpp"
 #include "vtu11.hpp"
 
 #include <sstream>
@@ -34,93 +34,93 @@ TEST_CASE("write_Pyramids3D_Test")
   std::vector<VtkCellType> types{ 10, 10, 10, 10, 14 };
   std::vector<VtkIndexType> offsets{ 4, 8, 12, 16, 21 };
   Vtu11UnstructuredMesh mesh{ points, connectivity, offsets, types };
-  
+
   std::vector<double> flashStrengthPoints{ 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0 };
   std::vector<double> cellColour{ 1.0, 2.0, 3.0, 4.0, 0.0 };
-  
+
   std::vector<DataSet> pointData{ DataSet{std::string("Flash Strength Points"), 1, flashStrengthPoints } };
   std::vector<DataSet> cellData{ DataSet{std::string("cell Colour"), 1, cellColour } };
-  
+
   auto readFile = [](const std::string& filename)
   {
   	std::ifstream file(filename);
-  
+
   	if (!file.is_open()) {
   		std::stringstream err_msg;
   		err_msg << filename << " could not be opened!";
   		throw std::runtime_error(err_msg.str());
   	}
-  
+
   	std::string contents, str;
-  
+
   	while (std::getline(file, str))
   	{
   	  contents += str + "\n";
   	}
-  
+
   	file.close();
-  
+
   	return contents;
   };
   std::string filename = "testfiles/pyramids_3D/test.vtu";
-  
+
   SECTION("ascii_3D")
   {
   	REQUIRE_NOTHROW(write(filename, mesh, pointData, cellData));
-  
+
   	auto written = readFile(filename);
   	auto expected = readFile("testfiles/pyramids_3D/ascii.vtu");
-  
+
   	CHECK(written == expected);
   }
-  
+
   // The files assume that, we need to add a big endian version
   REQUIRE(endianness() == "LittleEndian");
 
   SECTION("base64_3D")
   {
   	Base64BinaryWriter writer;
-  
+
   	REQUIRE_NOTHROW(write(filename, mesh, pointData, cellData, writer));
-  
+
   	auto written = readFile(filename);
   	auto expected = readFile("testfiles/pyramids_3D/base64.vtu");
-  
+
   	CHECK(written == expected);
   }
   //The file base64appended.vtu still cannot be opened within ParaView!!!
   SECTION("base64appended_3D")
   {
   	Base64BinaryAppendedWriter writer;
-  
+
   	REQUIRE_NOTHROW(write(filename, mesh, pointData, cellData, writer));
-  
+
   	auto written = readFile(filename);
   	auto expected = readFile("testfiles/pyramids_3D/base64appended.vtu");
-  
+
   	CHECK(written == expected);
   }
   SECTION("raw_3D")
   {
   	RawBinaryAppendedWriter writer;
-  
+
   	REQUIRE_NOTHROW(write(filename, mesh, pointData, cellData, writer));
-  
+
   	auto written = readFile(filename);
   	auto expected = readFile("testfiles/pyramids_3D/raw.vtu");
-  
+
   	CHECK(written == expected);
   }
 #ifdef VTU11_ENABLE_ZLIB
   SECTION("raw_compressed")
   {
   	CompressedRawBinaryAppendedWriter writer;
-  
+
   	REQUIRE_NOTHROW(write(filename, mesh, pointData, cellData, writer));
-  
+
   	auto written = readFile(filename);
   	auto expected = readFile("testfiles/pyramids_3D/raw_compressed.vtu");
-  
+
   	CHECK(written == expected);
   }
 #endif

--- a/test/write_hexahedras3D_test.cpp
+++ b/test/write_hexahedras3D_test.cpp
@@ -7,7 +7,7 @@
 //  License: BSD License ; see LICENSE
 //
 
-#include "external/catch2/catch.hpp"
+#include "vtu11_testing.hpp"
 #include "vtu11.hpp"
 
 #include <sstream>
@@ -32,17 +32,17 @@ TEST_CASE("hexahedras_test")
      0, 1, 2, 3, 4, 5, 6, 7, //0
      8, 9, 10, 11, 12, 13, 14, 15 //1, hexahedra - cubes
  };
-  
+
   std::vector<VtkIndexType> offsets{ 8, 16 };
   std::vector<VtkCellType> types{ 11, 11 };
 
   Vtu11UnstructuredMesh mesh{ points, connectivity, offsets, types };
-			
+
   std::vector<double> pointData1{ 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 5.0, 5.0, 5.0 };
   std::vector<double> pointData2{ 41.0, 13.0, 16.0, 81.0, 51.0, 31.0, 18.0, 12.0, 19.0, 21.0, 11.0, 19.0, 16.0, 45.0, 35.0, 58.0 };
   std::vector<double> cell_1{ 1.0, 2.0 };
   std::vector<double> cell_2{ 10.0, 20.0 };
-		
+
   std::vector<DataSet> pointData
   {
     DataSet {std::string("Point_Data_1"), 1, pointData1},
@@ -54,7 +54,7 @@ TEST_CASE("hexahedras_test")
     DataSet {std::string("Cell_1"), 1, cell_1},
     DataSet {std::string("Cell_2"), 1, cell_2}
   };
-  
+
   auto readFile = []( const std::string& filename )
   {
     std::ifstream file( filename );
@@ -77,7 +77,7 @@ TEST_CASE("hexahedras_test")
     return contents;
   };
   std::string filename = "testfiles/hexas_3D/test.vtu";
- 
+
   SECTION( "ascii_3D" )
   {
     REQUIRE_NOTHROW( write( filename, mesh, pointData, cellData ) );

--- a/test/write_icosahedron3D_test.cpp
+++ b/test/write_icosahedron3D_test.cpp
@@ -7,7 +7,7 @@
 //  License: BSD License ; see LICENSE
 //
 
-#include "external/catch2/catch.hpp"
+#include "vtu11_testing.hpp"
 #include "vtu11.hpp"
 
 #include <sstream>
@@ -63,9 +63,9 @@ TEST_CASE("write_test_icosahedron")
 
   std::vector<VtkIndexType> offsets { 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 85 };
   std::vector<VtkCellType> types { 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 14 };
-	
+
   Vtu11UnstructuredMesh mesh { points, connectivity, offsets, types };
-	
+
   std::vector<double> pointData1 { 100.0, 100.0, 100.0, 100.0, 0.0, 0.0, 0.0, 0.0, -100.0, -100.0, -100.0, -100.0, 0.0, -100.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
   std::vector<double> pointData2 { 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 1.0, -1.0, -1.0, -1.0, -1.0 };
   std::vector<double> cellHeight1 { -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, 0 };
@@ -82,7 +82,7 @@ TEST_CASE("write_test_icosahedron")
     DataSet { std::string( "Cell_Height_1" ), 1, cellHeight1 },
     DataSet { std::string( "Cell_Height_2" ), 1, cellHeight2 }
   };
-	
+
   auto readFile = []( const std::string& filename )
   {
     std::ifstream file( filename );
@@ -103,7 +103,7 @@ TEST_CASE("write_test_icosahedron")
     file.close();
 
     return contents;
-  };				
+  };
   std::string filename = "testfiles/icosahedron_3D/test.vtu";
   // The files assume that, we need to add a big endian version
   REQUIRE(endianness() == "LittleEndian");
@@ -118,7 +118,7 @@ TEST_CASE("write_test_icosahedron")
   SECTION( "base64_3D" )
   {
     Base64BinaryWriter writer;
-			
+
     REQUIRE_NOTHROW( write( filename, mesh, pointData, cellData, writer ) );
     auto written = readFile( filename );
     auto expected = readFile( "testfiles/icosahedron_3D/base64.vtu" );
@@ -158,7 +158,7 @@ TEST_CASE("write_test_icosahedron")
     CHECK( written == expected );
   }
 #endif
-		
+
 }
 
 } // namespace vtu11

--- a/test/write_square2D_test.cpp
+++ b/test/write_square2D_test.cpp
@@ -7,7 +7,7 @@
 //  License: BSD License ; see LICENSE
 //
 
-#include "external/catch2/catch.hpp"
+#include "vtu11_testing.hpp"
 #include "vtu11.hpp"
 
 #include <sstream>

--- a/test/xml_test.cpp
+++ b/test/xml_test.cpp
@@ -7,7 +7,7 @@
 //  License: BSD License ; see LICENSE
 //
 
-#include "external/catch2/catch.hpp"
+#include "vtu11_testing.hpp"
 #include "inc/xml.hpp"
 
 #include <sstream>


### PR DESCRIPTION
the idea is that one does not have to always include the `catch` header => this way it is cleaner IMO and it would be easier to change things under the hood

plus in this file we could create some of our own testing macros

what do you think?