### PR TITLE
adding filesystem to alias

### DIFF
--- a/vtu11/inc/alias.hpp
+++ b/vtu11/inc/alias.hpp
@@ -32,4 +32,21 @@ using VtkIndexType = std::int64_t;
 
 } // namespace vtu11
 
+// To dynamically select std::filesystem where available, you could use:
+#if defined(__cplusplus) && __cplusplus >= 201703L
+    #if __has_include(<filesystem>) // has_include is C++17
+        #include <filesystem>
+        namespace fs = std::filesystem;
+    #elif __has_include(<experimental/filesystem>)
+        #include <experimental/filesystem>
+        namespace fs = std::experimental::filesystem;
+    #else
+        #include "../external_libraries/filesystem/filesystem.hpp"
+        namespace fs = ghc::filesystem;
+    #endif
+#else
+    #include "../external_libraries/filesystem/filesystem.hpp"
+    namespace fs = ghc::filesystem;
+#endif
+
 #endif // VTU11_ALIAS_HPP


### PR DESCRIPTION
this way it can be used as e.g. `fs::remove("...")` after including `#include "inc/alias.hpp"`

do you think this is the correct place for this?