### PR TITLE
Use SFINAE instead of (run time) if to get rid of constexpr warnings

### DIFF
--- a/vtu11/impl/utilities_impl.hpp
+++ b/vtu11/impl/utilities_impl.hpp
@@ -10,7 +10,6 @@
 #ifndef VTU11_UTILITIES_IMPL_HPP
 #define VTU11_UTILITIES_IMPL_HPP
 
-#include <limits>
 #include <array>
 
 namespace vtu11
@@ -34,27 +33,6 @@ inline void writeTag( std::ostream& output,
 }
 
 } // namespace detail
-
-template<typename DataType>
-inline std::string dataTypeString( )
-{
-    std::string base;
-
-    if( std::numeric_limits<DataType>::is_integer && std::numeric_limits<DataType>::is_signed )
-    {
-        base = "Int";
-    }
-    else if( std::numeric_limits<DataType>::is_integer && !std::numeric_limits<DataType>::is_signed )
-    {
-        base = "UInt";
-    }
-    else
-    {
-        base = "Float";
-    }
-
-    return base + std::to_string( sizeof( DataType ) * 8 );
-}
 
 inline ScopedXmlTag::ScopedXmlTag( std::ostream& output,
                                    const std::string& name,

--- a/vtu11/impl/vtu11_impl.hpp
+++ b/vtu11/impl/vtu11_impl.hpp
@@ -213,8 +213,8 @@ void writeVtu( const std::string& filename,
 {
     auto mode = writeMode;
 
-    std::transform( mode.begin( ), mode.end ( ), mode.begin( ),
-        []( unsigned char c ){ return std::tolower( c ); } );
+    std::transform( mode.begin( ), mode.end ( ), mode.begin( ), []( unsigned char c )
+                    { return static_cast<unsigned char>( std::tolower( c ) ); } );
 
     if( mode == "ascii" )
     {

--- a/vtu11/inc/utilities.hpp
+++ b/vtu11/inc/utilities.hpp
@@ -13,15 +13,14 @@
 #include "vtu11/inc/alias.hpp"
 
 #include <functional>
+#include <limits>
+#include <type_traits>
 
 namespace vtu11
 {
 
 #define VTU11_THROW( message ) throw std::runtime_error( message )
 #define VTU11_CHECK( expr, message ) if( !( expr ) ) VTU11_THROW ( message )
-
-template<typename DataType>
-std::string dataTypeString( );
 
 std::string endianness( );
 
@@ -46,6 +45,39 @@ private:
 void writeEmptyTag( std::ostream& output,
                     const std::string& name,
                     const StringStringMap& attributes );
+
+template<typename T> inline
+std::string appendSizeInBits( const char* str )
+{
+    return str + std::to_string( sizeof( T ) * 8 );
+}
+
+// SFINAE if signed integer
+template<typename T> inline
+typename std::enable_if<std::numeric_limits<T>::is_integer && 
+                        std::numeric_limits<T>::is_signed, std::string>::type 
+    dataTypeString( )
+{
+    return appendSizeInBits<T>( "Int" );
+}
+
+// SFINAE if unsigned signed integer
+template<typename T> inline
+typename std::enable_if<std::numeric_limits<T>::is_integer &&
+                       !std::numeric_limits<T>::is_signed, std::string>::type 
+    dataTypeString( )
+{
+    return appendSizeInBits<T>( "UInt" );
+}
+
+// SFINAE if double or float
+template<typename T> inline
+typename std::enable_if<std::is_same<T, double>::value || 
+                        std::is_same<T, float>::value, std::string>::type 
+    dataTypeString( )
+{
+    return appendSizeInBits<T>( "Float" );
+}
 
 } // namespace vtu11
 


### PR DESCRIPTION
Previously we had an if which could be evaluated at compile time using a C++ 17 `if constexpr`. With additional warnings enabled some compilers suggest to do that, which of course doesn't work with C++ 11.  I changed this to work at compile time using SFINAE, which of course is much uglier, but works with C++ 11.