### PR TITLE
Make dummy mesh use const& and fix types in zlib writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 _Vtu11_ is a small C++ header-only library to write unstructured grids using the vtu file format. It keeps the mess of dealing with file writing in different formats away from you. Currently it does not add any features for setting up the required data structure because this vastly differs based on the context in which _vtu11_ is used.
 
+You can download a single header version in the latest release.
+
 ## Serial example
 
 ```cpp

--- a/vtu11/vtu11.hpp
+++ b/vtu11/vtu11.hpp
@@ -18,15 +18,15 @@ namespace vtu11
 
 struct Vtu11UnstructuredMesh
 {
-  std::vector<double>& points_;
-  std::vector<VtkIndexType>& connectivity_;
-  std::vector<VtkIndexType>& offsets_;
-  std::vector<VtkCellType>& types_;
+  const std::vector<double>& points_;
+  const std::vector<VtkIndexType>& connectivity_;
+  const std::vector<VtkIndexType>& offsets_;
+  const std::vector<VtkCellType>& types_;
 
-  std::vector<double>& points( ){ return points_; }
-  std::vector<VtkIndexType>& connectivity( ){ return connectivity_; }
-  std::vector<VtkIndexType>& offsets( ){ return offsets_; }
-  std::vector<VtkCellType>& types( ){ return types_; }
+  const std::vector<double>& points( ){ return points_; }
+  const std::vector<VtkIndexType>& connectivity( ){ return connectivity_; }
+  const std::vector<VtkIndexType>& offsets( ){ return offsets_; }
+  const std::vector<VtkCellType>& types( ){ return types_; }
 
   size_t numberOfPoints( ){ return points_.size( ) / 3; }
   size_t numberOfCells( ){ return types_.size( ); }


### PR DESCRIPTION
If I remember correctly I got some type conversion errors in the zlib writer, and I also added const's to the dummy mesh data structure. I'm sure we had some reason to not make it const, but as it is it doesn't really make any sense.