### PR TITLE
Unify and Pass OStream to the Base64Encoding

### DIFF
--- a/vtu11/impl/writer_impl.hpp
+++ b/vtu11/impl/writer_impl.hpp
@@ -103,8 +103,10 @@ inline void Base64BinaryWriter::writeData( std::ostream& output,
 {
   HeaderType numberOfBytes = data.size( ) * sizeof( T );
 
-  output << base64Encode( &numberOfBytes, &numberOfBytes + 1 );
-  output << base64Encode( data.begin( ), data.end( ) );
+  Base64EncodedOutput base64output;
+  base64output.writeOutputData( output, &numberOfBytes, 1 );
+  base64output.writeOutputData( output, data.begin( ), data.size( ) );
+  base64output.closeOutputData( output );
 
   output << "\n";
 }
@@ -146,14 +148,10 @@ inline void Base64BinaryAppendedWriter::writeAppended( std::ostream& output )
 {
   for( auto dataSet : appendedData )
   {
-    // looks like header and data has to be encoded at once
-    std::vector<char> data( dataSet.second + sizeof( HeaderType ) );
-
-    *reinterpret_cast<HeaderType*>( &data[0] ) = dataSet.second;
-
-    std::copy( dataSet.first, dataSet.first + dataSet.second, &data[ sizeof( HeaderType ) ] );
-
-    output << base64Encode( data.begin( ), data.end( ) );
+    Base64EncodedOutput base64output;
+    base64output.writeOutputData( output, &dataSet.second, 1 );
+    base64output.writeOutputData( output, dataSet.first, dataSet.second );
+    base64output.closeOutputData( output );
   }
 
   output << "\n";

--- a/vtu11/inc/utilities.hpp
+++ b/vtu11/inc/utilities.hpp
@@ -15,6 +15,7 @@
 #include <functional>
 #include <limits>
 #include <type_traits>
+#include <array>
 
 namespace vtu11
 {
@@ -23,6 +24,26 @@ namespace vtu11
 #define VTU11_CHECK( expr, message ) if( !( expr ) ) VTU11_THROW ( message )
 
 std::string endianness( );
+
+class Base64EncodedOutput
+{
+public:
+    template<typename TIteratorType>
+    void writeOutputData( std::ostream& output,
+                          TIteratorType begin,
+                          size_t n );
+
+    void closeOutputData( std::ostream& output );
+
+private:
+    static void encodeTriplet( std::ostream& output,
+                               const std::array<char, 3>& bytes,
+                               size_t padding );
+
+    size_t byteTripletIndex = 0;
+
+    std::array<char, 3> byteTriplet;
+};
 
 template<typename Iterator>
 std::string base64Encode( Iterator begin, Iterator end );
@@ -54,8 +75,8 @@ std::string appendSizeInBits( const char* str )
 
 // SFINAE if signed integer
 template<typename T> inline
-typename std::enable_if<std::numeric_limits<T>::is_integer && 
-                        std::numeric_limits<T>::is_signed, std::string>::type 
+typename std::enable_if<std::numeric_limits<T>::is_integer &&
+                        std::numeric_limits<T>::is_signed, std::string>::type
     dataTypeString( )
 {
     return appendSizeInBits<T>( "Int" );
@@ -64,7 +85,7 @@ typename std::enable_if<std::numeric_limits<T>::is_integer &&
 // SFINAE if unsigned signed integer
 template<typename T> inline
 typename std::enable_if<std::numeric_limits<T>::is_integer &&
-                       !std::numeric_limits<T>::is_signed, std::string>::type 
+                       !std::numeric_limits<T>::is_signed, std::string>::type
     dataTypeString( )
 {
     return appendSizeInBits<T>( "UInt" );
@@ -72,8 +93,8 @@ typename std::enable_if<std::numeric_limits<T>::is_integer &&
 
 // SFINAE if double or float
 template<typename T> inline
-typename std::enable_if<std::is_same<T, double>::value || 
-                        std::is_same<T, float>::value, std::string>::type 
+typename std::enable_if<std::is_same<T, double>::value ||
+                        std::is_same<T, float>::value, std::string>::type
     dataTypeString( )
 {
     return appendSizeInBits<T>( "Float" );


### PR DESCRIPTION
Hi all,

Following concerns were addressed in this PR.
1. When writing the header data in base64, there is always padding happening due to the fact that a `base64Encode` call is done for first the rawBytes size, and then again a call done for the actual data. This padding is not required for both appended and non-appended data. So I unified non-appended and appended data and removed this unnecessary padding.
2. now the encoded base64 string is written directly to the `std::ostream` then and there rather than building the whole `std::string` for the whole data set.

-- Todo:
- [ ]  Fix tests once the changes are agreed upon (I did not remove the padding from the reference cases).
- [ ]  Remove now unused `base64Encode` method.