### PR TITLE
[CI] add new Intel compiler

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [g++, clang++, icpc]
+        compiler: [g++, clang++, icpc, icx]
     timeout-minutes: 15
 
     steps:
@@ -30,7 +30,7 @@ jobs:
         sudo apt-get install clang
 
     - name: Install intel compiler
-      if: ${{ matrix.compiler == 'icpc' }}
+      if: "contains(matrix.compiler, 'ic')"
       run: |
         # see https://software.intel.com/content/www/us/en/develop/articles/installing-intel-oneapi-toolkits-via-apt.html#pkgtable
         cd /tmp
@@ -43,7 +43,7 @@ jobs:
 
     - name: Building
       run: |
-        if [ ${{ matrix.compiler }} = icpc ]; then
+        if [ ${{ matrix.compiler }} = icpc ] || [ ${{ matrix.compiler }} = icx ]; then
           source /opt/intel/oneapi/setvars.sh
         fi
         export CXX=${{ matrix.compiler }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [g++, clang++, icpc, icx]
+        compiler: [g++, clang++, icpc, icpx]
     timeout-minutes: 15
 
     steps:
@@ -30,7 +30,7 @@ jobs:
         sudo apt-get install clang
 
     - name: Install intel compiler
-      if: "contains(matrix.compiler, 'ic')"
+      if: "contains(matrix.compiler, 'icp')"
       run: |
         # see https://software.intel.com/content/www/us/en/develop/articles/installing-intel-oneapi-toolkits-via-apt.html#pkgtable
         cd /tmp
@@ -43,7 +43,7 @@ jobs:
 
     - name: Building
       run: |
-        if [ ${{ matrix.compiler }} = icpc ] || [ ${{ matrix.compiler }} = icx ]; then
+        if [ ${{ matrix.compiler }} = icpc ] || [ ${{ matrix.compiler }} = icpx ]; then
           source /opt/intel/oneapi/setvars.sh
         fi
         export CXX=${{ matrix.compiler }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,43 +36,43 @@ endif( ZLIB_FOUND )
 option( VTU11_ENABLE_TESTS "Build vtu11 unit tests." OFF )
 
 if( ${VTU11_ENABLE_TESTS} )
-     
-    set( VTU11_HEADERS 
-         vtu11/vtu11.hpp 
-         vtu11/inc/alias.hpp 
-         vtu11/inc/filesystem.hpp 
-         vtu11/inc/utilities.hpp 
-         vtu11/inc/writer.hpp 
-         vtu11/inc/zlibWriter.hpp 
-         vtu11/impl/utilities_impl.hpp 
-         vtu11/impl/vtu11_impl.hpp 
-         vtu11/impl/writer_impl.hpp 
+
+    set( VTU11_HEADERS
+         vtu11/vtu11.hpp
+         vtu11/inc/alias.hpp
+         vtu11/inc/filesystem.hpp
+         vtu11/inc/utilities.hpp
+         vtu11/inc/writer.hpp
+         vtu11/inc/zlibWriter.hpp
+         vtu11/impl/utilities_impl.hpp
+         vtu11/impl/vtu11_impl.hpp
+         vtu11/impl/writer_impl.hpp
          vtu11/impl/zlibWriter_impl.hpp )
-         
-    set( VTU11_TEST_SOURCES 
-         test/main_test.cpp 
-         test/pwrite_pyramids3D_test.cpp 
-         test/utilities_test.cpp 
-         test/vtu11_testing.cpp 
-         test/vtu11_testing.hpp 
-         test/write_hexahedras3D_test.cpp 
-         test/write_icosahedron3D_test.cpp 
-         test/write_pyramids3D_test.cpp 
+
+    set( VTU11_TEST_SOURCES
+         test/main_test.cpp
+         test/pwrite_pyramids3D_test.cpp
+         test/utilities_test.cpp
+         test/vtu11_testing.cpp
+         test/vtu11_testing.hpp
+         test/write_hexahedras3D_test.cpp
+         test/write_icosahedron3D_test.cpp
+         test/write_pyramids3D_test.cpp
          test/write_square2D_test.cpp )
-     
+
     add_executable( vtu11_testrunner ${VTU11_HEADERS} ${VTU11_TEST_SOURCES} )
- 
+
     target_link_libraries( vtu11_testrunner PRIVATE vtu11::vtu11 )
- 
+
     # Enable more warnings and treat warnings as errors
     if ( CMAKE_COMPILER_IS_GNUCXX )
-        target_compile_options( vtu11_testrunner PRIVATE -fPIC -pedantic -Wall -Wextra -Wcast-align 
+        target_compile_options( vtu11_testrunner PRIVATE -fPIC -pedantic -Wall -Wextra -Wcast-align
             -Wsuggest-attribute=cold -Wsuggest-attribute=pure -Wimport -Wsuggest-final-methods
             -Wsuggest-attribute=const -Wsuggest-attribute=format -Wsuggest-attribute=malloc
-            -Wsuggest-attribute=noreturn -Wformat-y2k -Wpacked -Wno-restrict -Wswitch-enum -Wwrite-strings 
-            -Wformat-nonliteral -Wformat-security -Wcast-qual -Wsuggest-override -Wsuggest-final-types 
-            -Wdisabled-optimization -Wformat=2 -Winit-self -Wlogical-op -Wmissing-include-dirs -Wnoexcept 
-            -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wsign-conversion 
+            -Wsuggest-attribute=noreturn -Wformat-y2k -Wpacked -Wno-restrict -Wswitch-enum -Wwrite-strings
+            -Wformat-nonliteral -Wformat-security -Wcast-qual -Wsuggest-override -Wsuggest-final-types
+            -Wdisabled-optimization -Wformat=2 -Winit-self -Wlogical-op -Wmissing-include-dirs -Wnoexcept
+            -Wold-style-cast -Woverloaded-virtual -Wredundant-decls -Wshadow -Wsign-conversion
             -Wsign-promo -Wstrict-null-sentinel -Wstrict-overflow=5 -Wundef -Werror )
 
     elseif( MSVC )
@@ -81,6 +81,9 @@ if( ${VTU11_ENABLE_TESTS} )
         # Note: min value is c++14 => 201402L (c++11 does not exist, will also output 201402L)
         target_compile_options( vtu11_testrunner PRIVATE /Zc:__cplusplus /W3 /EHsc /WX )
 
+    elseif( CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM" )
+        target_compile_options( vtu11_testrunner PRIVATE -Wall -Werror )
+
     elseif( CMAKE_CXX_COMPILER_ID MATCHES "Intel" )
         target_compile_options( vtu11_testrunner PRIVATE -Wall -Werror-all )
 
@@ -88,9 +91,9 @@ if( ${VTU11_ENABLE_TESTS} )
         target_compile_options( vtu11_testrunner PRIVATE -Wall -Werror )
 
     endif ( CMAKE_COMPILER_IS_GNUCXX )
-        
+
     include(CTest)
-   
+
     include("${CMAKE_CURRENT_SOURCE_DIR}/test/catch2/Catch.cmake")
 
     catch_discover_tests( vtu11_testrunner )


### PR DESCRIPTION
icc/icpc are deprecated in favor of icx/icpx. Using icc gives the following warning:
`icpc: remark #10441: The Intel(R) C++ Compiler Classic (ICC) is deprecated and will be removed from product release in the second half of 2023. The Intel(R) oneAPI DPC++/C++ Compiler (ICX) is the recommended compiler moving forward. Please transition to use this compiler. Use '-diag-disable=10441' to disable this message.`

For reference, this is how I added this compiler in [Kratos](https://github.com/KratosMultiphysics/Kratos/pull/10476)